### PR TITLE
KikoPlay.pro: fix downloadsetting move

### DIFF
--- a/KikoPlay.pro
+++ b/KikoPlay.pro
@@ -98,7 +98,6 @@ SOURCES += \
     UI/downloadwindow.cpp \
     UI/adduritask.cpp \
     UI/selecttorrentfile.cpp \
-    UI/downloadsetting.cpp \
     UI/poolmanager.cpp \
     UI/checkupdate.cpp \
     Play/Danmu/Provider/iqiyiprovider.cpp \


### PR DESCRIPTION
In commit https://github.com/Protostars/KikoPlay/commit/e66730fb113a333ff190878970e85152c8368cdc
UI/downloadsetting.cpp renamed to UI/settings/downloadpage.cpp.
The UI/downloadsetting.cpp should be removed in pro file.
